### PR TITLE
Fix forestdb headers include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Go bindings for ForestDB
 
 1.  Obtain and build forestdb: https://github.com/couchbaselabs/forestdb (run `make install` to install the library)
 1.  Install header files to system location
-  1. On Ubuntu 14.04: `cd <forestdb_project_dir> && mkdir /usr/local/include/forestdb && cp include/libforestdb/* /usr/local/include/forestdb`
+  1. On Ubuntu 14.04: `cd <forestdb_project_dir> && mkdir /usr/local/include/libforestdb && cp include/libforestdb/* /usr/local/include/libforestdb`
 1.  `go get -u -v -t github.com/couchbaselabs/goforestdb`
 
 ## Documentation

--- a/commit.go
+++ b/commit.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 // Options to be passed to Commit()

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (

--- a/error.go
+++ b/error.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 const (

--- a/examples/custom_comparator/comparator.c
+++ b/examples/custom_comparator/comparator.c
@@ -1,4 +1,4 @@
-#include <forestdb/forestdb.h>
+#include <libforestdb/forestdb.h>
 #include "comparator.h"
 
 extern int CompareBytesReversed(void *key1, size_t keylen1, void *key2, size_t keylen2);

--- a/forestdb.go
+++ b/forestdb.go
@@ -11,7 +11,7 @@ package forestdb
 
 //#cgo LDFLAGS: -lforestdb
 //#include <stdlib.h>
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (

--- a/info.go
+++ b/info.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (

--- a/iterator.go
+++ b/iterator.go
@@ -9,7 +9,7 @@ package forestdb
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (

--- a/kv.go
+++ b/kv.go
@@ -10,7 +10,7 @@ package forestdb
 //  and limitations under the License.
 
 //#include <stdlib.h>
-//#include <forestdb/forestdb.h>
+//#include <libforestdb/forestdb.h>
 import "C"
 
 import (


### PR DESCRIPTION
Build system expects standard header directory path
used by the forestdb cmake builds.
