### PR TITLE
Add logging.

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -16,7 +16,9 @@ import "C"
 func (k *KVStore) SnapshotOpen(sn SeqNum) (*KVStore, error) {
 	rv := KVStore{}
 
+	Log.Tracef("fdb_snapshot_open call k:%p db:%v sn:%v", k, k.db, sn)
 	errNo := C.fdb_snapshot_open(k.db, &rv.db, C.fdb_seqnum_t(sn))
+	Log.Tracef("fdb_snapshot_open retn k:%p errNo:%v rv:%v", k, errNo, rv.db)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -25,7 +27,9 @@ func (k *KVStore) SnapshotOpen(sn SeqNum) (*KVStore, error) {
 
 // Rollback a database to a specified point represented by the sequence number
 func (k *KVStore) Rollback(sn SeqNum) error {
+	Log.Tracef("fdb_rollback call k:%p db:%v sn:%v", k, k.db, sn)
 	errNo := C.fdb_rollback(&k.db, C.fdb_seqnum_t(sn))
+	Log.Tracef("fdb_rollback retn k:%p errNo:%v db:%v", k, errNo, k.db)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}

--- a/config.go
+++ b/config.go
@@ -181,7 +181,9 @@ func (c *Config) SetCompactorSleepDuration(s uint64) {
 
 // DefaultConfig gets the default ForestDB config
 func DefaultConfig() *Config {
+	Log.Debugf("fdb_get_default_config call")
 	config := C.fdb_get_default_config()
+	Log.Debugf("fdb_get_default_config ret config:%v", config)
 	return &Config{
 		config: &config,
 	}
@@ -206,7 +208,9 @@ func (c *KVStoreConfig) SetCustomCompare(comparator unsafe.Pointer) {
 
 // DefaultConfig gets the default ForestDB config
 func DefaultKVStoreConfig() *KVStoreConfig {
+	Log.Debugf("fdb_get_default_kvs_config call")
 	config := C.fdb_get_default_kvs_config()
+	Log.Debugf("fdb_get_default_kvs_config ret config:%v", config)
 	return &KVStoreConfig{
 		config: &config,
 	}

--- a/doc.go
+++ b/doc.go
@@ -45,8 +45,10 @@ func NewDoc(key, meta, body []byte) (*Doc, error) {
 
 	rv := Doc{}
 
+	Log.Tracef("fdb_doc_create call k:%p doc:%v m:%v b:%v", k, rv.doc, m, b)
 	errNo := C.fdb_doc_create(&rv.doc,
 		k, C.size_t(lenk), m, C.size_t(lenm), b, C.size_t(lenb))
+	Log.Tracef("fdb_doc_create ret k:%p errNo:%v doc:%v", k, errNo, rv.doc)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -68,7 +70,9 @@ func (d *Doc) Update(meta, body []byte) error {
 
 	lenm := len(meta)
 	lenb := len(body)
+	Log.Tracef("fdb_doc_update call d:%p doc:%v m:%v b:%v", d, d.doc, m, b)
 	errNo := C.fdb_doc_update(&d.doc, m, C.size_t(lenm), b, C.size_t(lenb))
+	Log.Tracef("fdb_doc_update retn d:%p errNo:%v doc:%v m:%v b:%v", d, errNo, d.doc, m, b)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -113,7 +117,9 @@ func (d *Doc) Deleted() bool {
 
 // Close releases resources allocated to this document
 func (d *Doc) Close() error {
+	Log.Tracef("fdb_doc_free call d:%p doc:%v", d, d.doc)
 	errNo := C.fdb_doc_free(d.doc)
+	Log.Tracef("fdb_doc_free retn d:%p errNo:%v", d, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}

--- a/file.go
+++ b/file.go
@@ -34,44 +34,14 @@ func Open(filename string, config *Config) (*File, error) {
 	defer C.free(unsafe.Pointer(dbname))
 
 	rv := File{}
+	Log.Tracef("fdb_open call rv:%p dbname:%v conf:%v", &rv, dbname, config.config)
 	errNo := C.fdb_open(&rv.dbfile, dbname, config.config)
+	Log.Tracef("fdb_open ret rv:%p errNo:%v rv:%v", &rv, errNo, rv)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
 	return &rv, nil
 }
-
-// FIXME disabling this for now, as I can't get it
-// to work as I expect.  Set the comparator in the
-// KVStoreConfig directly.
-
-// func OpenCustomCmp(filename string, config *Config, cmp map[string]unsafe.Pointer) (*File, error) {
-
-// 	// prepare the custom comparator
-// 	num_functions := C.size_t(len(cmp))
-// 	kvs_names := make([]*C.char, len(cmp))
-// 	funcs := make([]C.fdb_custom_cmp_variable, len(cmp))
-// 	i := 0
-// 	for cmpk, cmpv := range cmp {
-// 		kvs_names[i] = C.CString(cmpk)
-// 		funcs[i] = C.fdb_custom_cmp_variable(cmpv)
-// 		i++
-// 	}
-
-// 	if config == nil {
-// 		config = DefaultConfig()
-// 	}
-
-// 	dbname := C.CString(filename)
-// 	defer C.free(unsafe.Pointer(dbname))
-
-// 	rv := File{}
-// 	errNo := C.fdb_open_custom_cmp(&rv.dbfile, dbname, config.config, num_functions, &kvs_names[0], &funcs[0])
-// 	if errNo != RESULT_SUCCESS {
-// 		return nil, Error(errNo)
-// 	}
-// 	return &rv, nil
-// }
 
 // Options to be passed to Commit()
 type CommitOpt uint8
@@ -85,7 +55,9 @@ const (
 
 // Commit all pending changes into disk.
 func (f *File) Commit(opt CommitOpt) error {
+	Log.Tracef("fdb_commit call f:%p dbfile:%v opt:%v", f, f.dbfile, opt)
 	errNo := C.fdb_commit(f.dbfile, C.fdb_commit_opt_t(opt))
+	Log.Tracef("fdb_commit retn f:%p errNo:%v", f, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -98,7 +70,9 @@ func (f *File) Compact(newfilename string) error {
 	fn := C.CString(newfilename)
 	defer C.free(unsafe.Pointer(fn))
 
+	Log.Tracef("fdb_compact call f:%p dbfile:%v fn:%v", f, f.dbfile, fn)
 	errNo := C.fdb_compact(f.dbfile, fn)
+	Log.Tracef("fdb_compact retn f:%p errNo:%v", f, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -112,7 +86,9 @@ func (f *File) CompactUpto(newfilename string, sm *SnapMarker) error {
 	fn := C.CString(newfilename)
 	defer C.free(unsafe.Pointer(fn))
 
+	Log.Tracef("fdb_compact_upto call f:%p dbfile:%v fn:%v marker:%v", f, f.dbfile, fn, sm.marker)
 	errNo := C.fdb_compact_upto(f.dbfile, fn, sm.marker)
+	Log.Tracef("fdb_compact_upto retn f:%p errNo:%v", f, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -121,13 +97,18 @@ func (f *File) CompactUpto(newfilename string, sm *SnapMarker) error {
 
 // EstimateSpaceUsed returns the overall disk space actively used by the current database file
 func (f *File) EstimateSpaceUsed() int {
-	return int(C.fdb_estimate_space_used(f.dbfile))
+	Log.Tracef("fdb_estimate_space_used call f:%p dbfile:%v", f, f.dbfile)
+	rv := int(C.fdb_estimate_space_used(f.dbfile))
+	Log.Tracef("fdb_estimate_space_used retn f:%p rv:%v", f, rv)
+	return rv
 }
 
 // DbInfo returns the information about a given database handle
 func (f *File) Info() (*FileInfo, error) {
 	rv := FileInfo{}
+	Log.Tracef("fdb_get_file_info call f:%p dbfile:%v", f, f.dbfile)
 	errNo := C.fdb_get_file_info(f.dbfile, &rv.info)
+	Log.Tracef("fdb_get_file_info retn f:%p errNo:%v, info:%v", f, errNo, rv.info)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -138,7 +119,9 @@ func (f *File) Info() (*FileInfo, error) {
 
 // Close the database file
 func (f *File) Close() error {
+	Log.Tracef("fdb_close call f:%p dbfile:%v", f, f.dbfile)
 	errNo := C.fdb_close(f.dbfile)
+	Log.Tracef("fdb_close retn f:%p errNo:%v", f, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -158,7 +141,9 @@ func (f *File) OpenKVStore(name string, config *KVStoreConfig) (*KVStore, error)
 	}
 	kvsname := C.CString(name)
 	defer C.free(unsafe.Pointer(kvsname))
+	Log.Tracef("fdb_kvs_open call f:%p dbfile:%v kvsname:%v config:%v", f, f.dbfile, kvsname, config.config)
 	errNo := C.fdb_kvs_open(f.dbfile, &rv.db, kvsname, config.config)
+	Log.Tracef("fdb_kvs_open retn f:%p errNo:%v db:%v", f, errNo, rv.db)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -182,7 +167,9 @@ func Destroy(filename string, config *Config) error {
 	dbname := C.CString(filename)
 	defer C.free(unsafe.Pointer(dbname))
 
+	Log.Tracef("fdb_destroy call dbname:%v config:%v", dbname, config.config)
 	errNo := C.fdb_destroy(dbname, config.config)
+	Log.Tracef("fdb_destroy retn dbname:%v errNo:%v", dbname, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}

--- a/forestdb.go
+++ b/forestdb.go
@@ -22,7 +22,9 @@ type KVStore struct {
 
 // Close the KVStore and release related resources.
 func (k *KVStore) Close() error {
+	Log.Tracef("fdb_kvs_close call k:%p db:%v", k, k.db)
 	errNo := C.fdb_kvs_close(k.db)
+	Log.Tracef("fdb_kvs_close retn k:%p errNo:%v", k, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -32,7 +34,9 @@ func (k *KVStore) Close() error {
 // Info returns the information about a given kvstore
 func (k *KVStore) Info() (*KVStoreInfo, error) {
 	rv := KVStoreInfo{}
+	Log.Tracef("fdb_get_kvs_info call k:%p db:%v", k, k.db)
 	errNo := C.fdb_get_kvs_info(k.db, &rv.info)
+	Log.Tracef("fdb_kvs_close retn k:%p errNo:%v info:%v", k, errNo, rv.info)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -41,7 +45,9 @@ func (k *KVStore) Info() (*KVStoreInfo, error) {
 
 // Get retrieves the metadata and doc body for a given key
 func (k *KVStore) Get(doc *Doc) error {
+	Log.Tracef("fdb_get call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_get(k.db, doc.doc)
+	Log.Tracef("fdb_get retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -50,7 +56,9 @@ func (k *KVStore) Get(doc *Doc) error {
 
 // GetMetaOnly retrieves the metadata for a given key
 func (k *KVStore) GetMetaOnly(doc *Doc) error {
+	Log.Tracef("fdb_get_metaonly call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_get_metaonly(k.db, doc.doc)
+	Log.Tracef("fdb_get_metaonly retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -59,7 +67,9 @@ func (k *KVStore) GetMetaOnly(doc *Doc) error {
 
 // GetBySeq retrieves the metadata and doc body for a given sequence number
 func (k *KVStore) GetBySeq(doc *Doc) error {
+	Log.Tracef("fdb_get_byseq call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_get_byseq(k.db, doc.doc)
+	Log.Tracef("fdb_get_byseq retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -68,7 +78,9 @@ func (k *KVStore) GetBySeq(doc *Doc) error {
 
 // GetMetaOnlyBySeq retrieves the metadata for a given sequence number
 func (k *KVStore) GetMetaOnlyBySeq(doc *Doc) error {
+	Log.Tracef("fdb_get_metaonly_byseq call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_get_metaonly_byseq(k.db, doc.doc)
+	Log.Tracef("fdb_get_metaonly_byseq retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -77,7 +89,9 @@ func (k *KVStore) GetMetaOnlyBySeq(doc *Doc) error {
 
 // GetByOffset retrieves a doc's metadata and body with a given doc offset in the database file
 func (k *KVStore) GetByOffset(doc *Doc) error {
+	Log.Tracef("fdb_get_byoffset call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_get_byoffset(k.db, doc.doc)
+	Log.Tracef("fdb_get_byoffset retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -86,7 +100,9 @@ func (k *KVStore) GetByOffset(doc *Doc) error {
 
 // Set update the metadata and doc body for a given key
 func (k *KVStore) Set(doc *Doc) error {
+	Log.Tracef("fdb_set call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_set(k.db, doc.doc)
+	Log.Tracef("fdb_set retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -95,7 +111,9 @@ func (k *KVStore) Set(doc *Doc) error {
 
 // Delete deletes a key, its metadata and value
 func (k *KVStore) Delete(doc *Doc) error {
+	Log.Tracef("fdb_del call k:%p db:%v doc:%v", k, k.db, doc.doc)
 	errNo := C.fdb_del(k.db, doc.doc)
+	Log.Tracef("fdb_set retn k:%p errNo:%v doc:%v", k, errNo, doc.doc)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -104,7 +122,9 @@ func (k *KVStore) Delete(doc *Doc) error {
 
 // Shutdown destroys all the resources (e.g., buffer cache, in-memory WAL indexes, daemon compaction thread, etc.) and then shutdown the ForestDB engine
 func Shutdown() error {
+	Log.Tracef("fdb_shutdown call")
 	errNo := C.fdb_shutdown()
+	Log.Tracef("fdb_shutdown retn errNo:%v", errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -47,7 +47,9 @@ type Iterator struct {
 
 // Prev advances the iterator backwards
 func (i *Iterator) Prev() error {
+	Log.Tracef("fdb_iterator_prev call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_prev(i.iter)
+	Log.Tracef("fdb_iterator_prev retn i:%p iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -56,7 +58,9 @@ func (i *Iterator) Prev() error {
 
 // Next advances the iterator forward
 func (i *Iterator) Next() error {
+	Log.Tracef("fdb_iterator_next call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_next(i.iter)
+	Log.Tracef("fdb_iterator_next retn i:%p iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -66,7 +70,9 @@ func (i *Iterator) Next() error {
 // Get gets the current item (key, metadata, doc body) from the iterator
 func (i *Iterator) Get() (*Doc, error) {
 	rv := Doc{}
+	Log.Tracef("fdb_iterator_get call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_get(i.iter, &rv.doc)
+	Log.Tracef("fdb_iterator_get retn i:%p iter:%v doc:%v", i, errNo, i.iter, rv.doc)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -76,7 +82,9 @@ func (i *Iterator) Get() (*Doc, error) {
 // GetMetaOnly gets the current item (key, metadata, offset to doc body) from the iterator
 func (i *Iterator) GetMetaOnly() (*Doc, error) {
 	rv := Doc{}
+	Log.Tracef("fdb_iterator_get_metaonly call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_get_metaonly(i.iter, &rv.doc)
+	Log.Tracef("fdb_iterator_get_metaonly retn i:%p iter:%v doc:%v", i, errNo, i.iter, rv.doc)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -94,7 +102,9 @@ func (i *Iterator) Seek(seekKey []byte, dir SeekOpt) error {
 	if lensk != 0 {
 		sk = unsafe.Pointer(&seekKey[0])
 	}
+	Log.Tracef("fdb_iterator_seek call i:%p iter:%v sk:%v dir:%v", i, i.iter, sk, dir)
 	errNo := C.fdb_iterator_seek(i.iter, sk, C.size_t(lensk), C.fdb_iterator_seek_opt_t(dir))
+	Log.Tracef("fdb_iterator_seek retn i:%p errNo:%v iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -104,7 +114,9 @@ func (i *Iterator) Seek(seekKey []byte, dir SeekOpt) error {
 // SeekMin moves iterator to the smallest key
 // of the iteration
 func (i *Iterator) SeekMin() error {
+	Log.Tracef("fdb_iterator_seek_to_min call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_seek_to_min(i.iter)
+	Log.Tracef("fdb_iterator_seek_to_min retn i:%p errNo:%v iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -114,7 +126,9 @@ func (i *Iterator) SeekMin() error {
 // SeekMax moves iterator to the largest key
 // of the iteration
 func (i *Iterator) SeekMax() error {
+	Log.Tracef("fdb_iterator_seek_to_max call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_seek_to_max(i.iter)
+	Log.Tracef("fdb_iterator_seek_to_max retn i:%p errNo:%v iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -123,7 +137,9 @@ func (i *Iterator) SeekMax() error {
 
 // Close the iterator and free its associated resources
 func (i *Iterator) Close() error {
+	Log.Tracef("fdb_iterator_close call i:%p iter:%v", i, i.iter)
 	errNo := C.fdb_iterator_close(i.iter)
+	Log.Tracef("fdb_iterator_close retn i:%p errNo:%v iter:%v", i, errNo, i.iter)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -146,7 +162,9 @@ func (k *KVStore) IteratorInit(startKey, endKey []byte, opt IteratorOpt) (*Itera
 	}
 
 	rv := Iterator{}
+	Log.Tracef("fdb_iterator_init call k:%p db:%v sk:%v ek:%v opt:%v", k, k.db, sk, ek, opt)
 	errNo := C.fdb_iterator_init(k.db, &rv.iter, sk, C.size_t(lensk), ek, C.size_t(lenek), C.fdb_iterator_opt_t(opt))
+	Log.Tracef("fdb_iterator_init retn k:%p rv:%v", k, rv.iter)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -156,7 +174,9 @@ func (k *KVStore) IteratorInit(startKey, endKey []byte, opt IteratorOpt) (*Itera
 // IteratorSequenceInit create an iterator to traverse a ForestDB snapshot by sequence number range
 func (k *KVStore) IteratorSequenceInit(startSeq, endSeq SeqNum, opt IteratorOpt) (*Iterator, error) {
 	rv := Iterator{}
+	Log.Tracef("fdb_iterator_sequence_init call k:%p db:%v sseq:%v eseq:%v opt:%v", k, k.db, startSeq, endSeq, opt)
 	errNo := C.fdb_iterator_sequence_init(k.db, &rv.iter, C.fdb_seqnum_t(startSeq), C.fdb_seqnum_t(endSeq), C.fdb_iterator_opt_t(opt))
+	Log.Tracef("fdb_iterator_sequence_init retn k:%p rv:%v", k, rv.iter)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}

--- a/kv.go
+++ b/kv.go
@@ -29,7 +29,9 @@ func (k *KVStore) GetKV(key []byte) ([]byte, error) {
 	var bodyLen C.size_t
 	var bodyPointer unsafe.Pointer
 
+	Log.Tracef("fdb_get_kv call k:%p db:%v kk:%v", k, k.db, kk)
 	errNo := C.fdb_get_kv(k.db, kk, C.size_t(lenk), &bodyPointer, &bodyLen)
+	Log.Tracef("fdb_get_kv retn k:%p errNo:%v body:%p len:%v", k, errNo, bodyPointer, bodyLen)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -55,7 +57,9 @@ func (k *KVStore) SetKV(key, value []byte) error {
 	lenk := len(key)
 	lenv := len(value)
 
+	Log.Tracef("fdb_set_kv call k:%p db:%v kk:%v v:%v", k, k.db, kk, v)
 	errNo := C.fdb_set_kv(k.db, kk, C.size_t(lenk), v, C.size_t(lenv))
+	Log.Tracef("fdb_set_kv retn k:%p errNo:%v", k, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}
@@ -72,7 +76,9 @@ func (k *KVStore) DeleteKV(key []byte) error {
 
 	lenk := len(key)
 
+	Log.Tracef("fdb_del_kv call k:%p db:%v kk:%v", k, k.db, kk)
 	errNo := C.fdb_del_kv(k.db, kk, C.size_t(lenk))
+	Log.Tracef("fdb_del_kv retn k:%p errNo:%v", k, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,41 @@
+package forestdb
+
+// Logger interface
+type Logger interface {
+	// Warnings, logged by default.
+	Warnf(format string, v ...interface{})
+	// Errors, logged by default.
+	Errorf(format string, v ...interface{})
+	// Fatal errors. Will not terminate execution.
+	Fatalf(format string, v ...interface{})
+	// Informational messages.
+	Infof(format string, v ...interface{})
+	// Timing utility
+	Debugf(format string, v ...interface{})
+	// Program execution tracing. Not logged by default
+	Tracef(format string, v ...interface{})
+}
+
+type Dummy struct {
+}
+
+func (*Dummy) Fatalf(_ string, _ ...interface{}) {
+}
+
+func (*Dummy) Errorf(_ string, _ ...interface{}) {
+}
+
+func (*Dummy) Warnf(_ string, _ ...interface{}) {
+}
+
+func (*Dummy) Infof(_ string, _ ...interface{}) {
+}
+
+func (*Dummy) Debugf(_ string, _ ...interface{}) {
+}
+
+func (*Dummy) Tracef(_ string, _ ...interface{}) {
+}
+
+// Logger to use
+var Log Logger = &Dummy{}

--- a/snapshot_marker.go
+++ b/snapshot_marker.go
@@ -30,7 +30,9 @@ func (f *File) GetAllSnapMarkers() (*SnapInfos, error) {
 	snapInfos := &SnapInfos{}
 	var numMarkers C.uint64_t
 
+	Log.Tracef("get_all_snap_markers call f:%p db:%v", f, f.dbfile)
 	errNo := C.fdb_get_all_snap_markers(f.dbfile, &snapInfos.cinfo, &numMarkers)
+	Log.Tracef("get_all_snap_markers retn f:%p errNo:%v cinfo:%v num:%v", f, errNo, snapInfos.cinfo, numMarkers)
 	if errNo != RESULT_SUCCESS {
 		return nil, Error(errNo)
 	}
@@ -51,8 +53,9 @@ func (s *SnapInfos) SnapInfoList() []SnapInfo {
 }
 
 func (s *SnapInfos) FreeSnapMarkers() error {
-
+	Log.Tracef("free_snap_markers call s:%p cinfo:%v", s, s.cinfo)
 	errNo := C.fdb_free_snap_markers(s.cinfo, C.uint64_t(len(s.snapInfo)))
+	Log.Tracef("free_snap_markers retn s:%p errNo:%v", s, errNo)
 	if errNo != RESULT_SUCCESS {
 		return Error(errNo)
 	}


### PR DESCRIPTION
In order to trace what happened when debugging forestdb crashes,
it is useful to log sufficient information to show sequence of
operations and perhaps useful memory locations

Change-Id: I38691c79686ded51303a1839002a1e4c408801d1
